### PR TITLE
Add tag : arm64

### DIFF
--- a/7.3.1611-aarch64/tags
+++ b/7.3.1611-aarch64/tags
@@ -1,4 +1,8 @@
 7.3-aarch64
+7.3-arm64
 7.3.1611-aarch64
+7.3.1611-arm64
 7-aarch64
+7-arm64
 aarch64
+arm64


### PR DESCRIPTION
Following https://github.com/multiarch/centos/pull/6, can we add `arm64` tags ?

`arm64` tag is used in some other multiarch images like [multiarch/ubuntu-core/tags](https://hub.docker.com/r/multiarch/ubuntu-core/tags/)

Let me know if you prefer to standardize that over all images.
