### PR TITLE
Add README.md and .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: xenial
+sudo: required
+services:
+  - docker
+language: bash
+
+before_install:
+  - docker run --rm --privileged multiarch/qemu-user-static:register
+
+script:
+  - ./update.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# :earth_africa: centos [![Build Status](https://travis-ci.org/multiarch/centos.svg?branch=master)](https://travis-ci.org/multiarch/centos)
+
+![](https://raw.githubusercontent.com/multiarch/dockerfile/master/logo.jpg)
+
+Multiarch CentOS images for Docker.
+
+* `multiarch/centos` on [Docker Hub](https://hub.docker.com/r/multiarch/centos/)
+* [Available tags](https://hub.docker.com/r/multiarch/centos/tags/)
+
+## Usage
+
+Later.
+
+## License
+
+MIT


### PR DESCRIPTION
Travis is already enabled.
https://travis-ci.org/multiarch/centos

Modified README is here.
https://github.com/junaruga/centos/blob/feature/add-readme-and-travis/README.md

I am planning to support latest CentOS images with automated build and push after this PR will be merged, like `multiarch/fedora`.
https://github.com/multiarch/fedora/pull/5
