### PR TITLE
Implement container image push.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 services:
-  - docker
+    - docker
 language: bash
 addons:
     apt:
@@ -13,6 +13,9 @@ addons:
             - libguestfs-tools
 env:
     global:
+        - QEMU_VER=v3.1.0-3
+        - DOCKER_SERVER=docker.io
+        - DOCKER_REPO=$DOCKER_SERVER/multiarch/centos
         # Enable below environment variables for debug when virt-tar-out shows error.
         # - LIBGUESTFS_DEBUG=1
         # - LIBGUESTFS_TRACE=1
@@ -31,8 +34,15 @@ env:
         # - VERSION=7.6.1810-ppc64le
 
 before_install:
-  - docker run --rm --privileged multiarch/qemu-user-static:register
+    - docker run --rm --privileged multiarch/qemu-user-static:register
 
 script:
-  - ./update.sh "${VERSION}"
-  - docker images
+    - ./update.sh -v "${VERSION}" -u "${QEMU_VER}" -d "${DOCKER_REPO}"
+    - docker images
+
+after_success:
+    - |
+      if [[ "${TRAVIS_BRANCH}" == 'master' && "${TRAVIS_PULL_REQUEST}" == 'false' ]]; then
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin "${DOCKER_SERVER}" && \
+              docker push "${DOCKER_REPO}"
+      fi

--- a/repo
+++ b/repo
@@ -1,1 +1,0 @@
-multiarch/centos


### PR DESCRIPTION
I implemented a pipeline to the Docker Hub https://hub.docker.com/r/multiarch/centos/tags/ .

I tested it at my docker container repository, changing the setting in `.traivs.yml` like this.

```
-        - DOCKER_SERVER=docker.io
-        - DOCKER_REPO=$DOCKER_SERVER/multiarch/centos
+        # - DOCKER_SERVER=docker.io
+        # - DOCKER_REPO=$DOCKER_SERVER/multiarch/centos
+        - DOCKER_SERVER=quay.io
+        - DOCKER_REPO=$DOCKER_SERVER/junaruga/multiarch-centos
```

Here is the result. You can see the uploaded container images on the website.
https://quay.io/repository/junaruga/multiarch-centos?tab=tags

Below is also test for the images.
An error for 7-armhfp-iso-slim is expected. That's okay.

```
$ uname -m
x86_64

$ docker run --rm --privileged multiarch/qemu-user-static:register --reset

$ docker run --rm -t quay.io/junaruga/multiarch-centos:7-armhfp-iso-slim uname -m
standard_init_linux.go:187: exec user process caused "no such file or directory"

$ docker run --rm -t quay.io/junaruga/multiarch-centos:7-armhfp-iso uname -m
armv7l

$ docker run --rm -t quay.io/junaruga/multiarch-centos:7-armhfp-clean uname -m
armv7l
```

Like "multiarch/fedora", we need to set `DOCKER_USERNAME` and `DOCKER_PASSWORD` at this repository's Travis CI settings.
https://travis-ci.org/multiarch/centos/settings

I have a permission to edit the Settings. But I do not know the password.
So, @moul can you set it?

It's okay to merge this PR before setting it.